### PR TITLE
modify current inc cmd

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2111,6 +2111,13 @@ func TestTenantLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestTenantLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestTenantLogic_tenant_from_tenant(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2109,6 +2109,13 @@ func TestReadCommittedLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestReadCommittedLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestReadCommittedLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2102,6 +2102,13 @@ func TestRepeatableReadLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestRepeatableReadLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestRepeatableReadLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/temp_test
+++ b/pkg/sql/logictest/testdata/logic_test/temp_test
@@ -1,0 +1,13 @@
+
+statement ok
+GRANT admin TO testuser
+
+user testuser
+
+statement ok
+CREATE SEQUENCE foo
+
+query I
+SELECT nextval('foo')
+----
+1

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2080,6 +2080,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2087,6 +2087,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2101,6 +2101,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2080,6 +2080,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
@@ -2094,6 +2094,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.2/generated_test.go
@@ -2094,6 +2094,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2108,6 +2108,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2332,6 +2332,13 @@ func TestLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestLogic_temp_test(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "temp_test")
+}
+
 func TestLogic_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1788,6 +1788,11 @@ func TestSchemaChangeComparator_temp_table_txn(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/temp_table_txn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_temp_test(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/temp_test"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant"


### PR DESCRIPTION
batch inc cannot be used:
- it does not obey the max_value
- it should not be extended to obey max value.